### PR TITLE
Add support for Azure OpenAI for the solution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=your_openai_api_key_here
 FINANCIAL_DATASETS_API_KEY=your_financial_datasets_api_key_here
+AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here
+USE_AZURE_OPENAI=false

--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -1,8 +1,9 @@
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai.chat_models import ChatOpenAI
+from langchain_openai.chat_models import ChatOpenAI, AzureChatOpenAI
 
 from graph.state import AgentState, show_agent_reasoning
+import os
 
 
 ##### Portfolio Management Agent #####
@@ -69,8 +70,13 @@ def portfolio_management_agent(state: AgentState):
             "portfolio_stock": portfolio["stock"],
         }
     )
-    # Invoke the LLM
-    llm = ChatOpenAI(model="gpt-4o")
+    # Check the environment variable to decide which LLM to use
+    use_azure_openai = os.getenv("USE_AZURE_OPENAI", "false").lower() == "true"
+    if use_azure_openai:
+        llm = AzureChatOpenAI(model="gpt-4o")
+    else:
+        llm = ChatOpenAI(model="gpt-4o")
+        
     result = llm.invoke(prompt)
 
     # Create the portfolio management message


### PR DESCRIPTION
Add support for switching between OpenAI and Azure OpenAI models based on an environment variable.

* **portfolio_manager.py**
  - Import `AzureChatOpenAI` from `langchain_openai.chat_models`.
  - Add logic to check `USE_AZURE_OPENAI` environment variable.
  - Use `AzureChatOpenAI` if `USE_AZURE_OPENAI` is set to true.
  - Use `ChatOpenAI` if `USE_AZURE_OPENAI` is not set or false.

* **.env.example**
  - Add `AZURE_OPENAI_API_KEY` placeholder.
  - Add `USE_AZURE_OPENAI` placeholder.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sayanghosh123/ai-hedge-fund/pull/1?shareId=ace98e8e-2478-4ffb-970d-61663b2bee7e).